### PR TITLE
removed check for maven: maven not needed for this install

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -38,7 +38,6 @@ echo "##                                                             ##"
 echo "#################################################################"
 echo
 
-command -v mvn -q >/dev/null 2>&1 || { echo >&2 "Maven is required but not installed yet... aborting."; exit 1; }
 
 # make some checks first before proceeding.	
 if [ -r $SRC_DIR/$EAP ] || [ -L $SRC_DIR/$EAP ]; then


### PR DESCRIPTION
At a customer, I showed them your init.sh as an example how they can automate a BPMS installation in a container-less environment. They did not have maven installed and were reluctant to install it. I tried to run with the maven check disabled and that worked just fine...