### PR TITLE
Added installation of BPM Suite Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Software
 The following software is required to run this demo:
 - [JBoss EAP 7.0 installer](https://developers.redhat.com/download-manager/file/jboss-eap-7.0.0-installer.jar)
 - [JBoss BPM Suite 6.4.0.GA deployable for EAP 7](https://developers.redhat.com/download-manager/content/origin/files/sha256/be/be13e233f70054ed071ebde7c8129d59431a5eb5cbf95eee046627592b679a1f/jboss-bpmsuite-6.4.0.GA-deployable-eap7.x.zip)
+- [Red Hat JBoss BPM Suite 6.4 Update 4](https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=52491)
 - [7-Zip](http://www.7-zip.org/download.html) (Windows only): to overcome the Windows 260 character path length limit, we need 7-Zip to unzip the BPM Suite deployable.
 
 

--- a/init-docker.sh
+++ b/init-docker.sh
@@ -6,6 +6,7 @@ PRODUCT="JBoss BPM Suite"
 DOCKERFILE="support/docker/Dockerfile"
 SRC_DIR=./installs
 BPMS=jboss-bpmsuite-6.4.0.GA-deployable-eap7.x.zip
+BPMS_PATCH=jboss-bpmsuite-6.4.4-patch.zip
 EAP=jboss-eap-7.0.0-installer.jar
 VERSION=6.4
 
@@ -59,6 +60,16 @@ if [ -r $SRC_DIR/$BPMS ] || [ -L $SRC_DIR/$BPMS ]; then
 		echo
 else
 		echo Need to download $BPMS package from the Customer Portal
+		echo and place it in the $SRC_DIR directory to proceed...
+		echo
+		exit
+fi
+
+if [ -r $SRC_DIR/$BPMS_PATCH ] || [ -L $SRC_DIR/$BPMS_PATCH ]; then
+		echo Product sources are present...
+		echo
+else
+		echo Need to download $BPMS_PATCH package from the Customer Portal
 		echo and place it in the $SRC_DIR directory to proceed...
 		echo
 		exit

--- a/init.sh
+++ b/init.sh
@@ -12,6 +12,9 @@ SRC_DIR=./installs
 SUPPORT_DIR=./support
 PRJ_DIR=./projects
 BPMS=jboss-bpmsuite-6.4.0.GA-deployable-eap7.x.zip
+BPMS_PATCH_FOLDER=jboss-bpmsuite-6.4.4-patch
+BPMS_PATCH=$BPMS_PATCH_FOLDER.zip
+PATCH_DIR=$TARGET/$BPMS_PATCH_FOLDER
 EAP=jboss-eap-7.0.0-installer.jar
 #EAP_PATCH=jboss-eap-6.4.4-patch.zip
 VERSION=6.4
@@ -72,6 +75,16 @@ else
 		exit
 fi
 
+if [ -r $SRC_DIR/$BPMS_PATCH ] || [ -L $SRC_DIR/$BPMS_PATCH ]; then
+		echo Product sources are present...
+		echo
+else
+		echo Need to download $BPMS_PATCH package from the Customer Portal
+		echo and place it in the $SRC_DIR directory to proceed...
+		echo
+		exit
+fi
+
 # Remove the old JBoss instance, if it exists.
 if [ -x $JBOSS_HOME ]; then
 		echo "  - removing existing JBoss product..."
@@ -106,6 +119,25 @@ echo "Deploying JBoss BPM Suite now..."
 echo
 unzip -qo $SRC_DIR/$BPMS -d $TARGET
 #java -jar $SRC_DIR/$BPMS $SUPPORT_DIR/installation-bpms -variablefile $SUPPORT_DIR/installation-bpms.variables
+if [ $? -ne 0 ]; then
+	echo
+	echo Error occurred during $PRODUCT installation!
+	exit
+fi
+
+echo
+echo "Instaling JBoss BPM Suite patch..."
+echo
+unzip -q $SRC_DIR/$BPMS_PATCH -d $TARGET
+if [ $? -ne 0 ]; then
+	echo
+	echo Error occurred during $PRODUCT installation!
+	exit
+fi
+
+cd $BPMS_PATCH_FOLDER \
+	&& ./apply-updates.sh $BPMS_HOME eap7.x \
+	&& cd - &> /dev/null
 if [ $? -ne 0 ]; then
 	echo
 	echo Error occurred during $PRODUCT installation!

--- a/support/docker/Dockerfile
+++ b/support/docker/Dockerfile
@@ -10,6 +10,7 @@ ENV BPMS_VERSION_MAJOR 6
 ENV BPMS_VERSION_MINOR 4
 ENV BPMS_VERSION_MICRO 0
 ENV BPMS_VERSION_PATCH GA
+ENV BPMS_VERSION_MICRO_PATCH 4
 
 ENV EAP_VERSION_MAJOR 7
 ENV EAP_VERSION_MINOR 0
@@ -18,13 +19,15 @@ ENV EAP_VERSION_MICRO 0
 
 ENV EAP_INSTALLER=jboss-eap-$EAP_VERSION_MAJOR.$EAP_VERSION_MINOR.$EAP_VERSION_MICRO-installer.jar
 ENV BPMS_DEPLOYABLE=jboss-bpmsuite-$BPMS_VERSION_MAJOR.$BPMS_VERSION_MINOR.$BPMS_VERSION_MICRO.$BPMS_VERSION_PATCH-deployable-eap7.x.zip
+ENV BPMS_PATCH_FOLDER=jboss-bpmsuite-$BPMS_VERSION_MAJOR.$BPMS_VERSION_MINOR.$BPMS_VERSION_MICRO_PATCH-patch
+ENV BPMS_PATCH=$BPMS_PATCH_FOLDER.zip
 
 # ADD Installation Files
-COPY support/installation-eap support/installation-eap.variables installs/$BPMS_DEPLOYABLE installs/$EAP_INSTALLER /opt/jboss/
+COPY support/installation-eap support/installation-eap.variables installs/$BPMS_DEPLOYABLE installs/$BPMS_PATCH installs/$EAP_INSTALLER /opt/jboss/
 
 # Update Permissions on Installers
 USER root
-RUN chown 1000:1000 /opt/jboss/$EAP_INSTALLER /opt/jboss/$BPMS_DEPLOYABLE
+RUN chown 1000:1000 /opt/jboss/$EAP_INSTALLER /opt/jboss/$BPMS_DEPLOYABLE /opt/jboss/$BPMS_PATCH
 USER 1000
 
 # Prepare and run installer and cleanup installation components
@@ -32,8 +35,11 @@ RUN sed -i "s:<installpath>.*</installpath>:<installpath>$BPMS_HOME</installpath
     && java -jar /opt/jboss/$EAP_INSTALLER  /opt/jboss/installation-eap -variablefile /opt/jboss/installation-eap.variables \
     #&& $BPMS_HOME/bin/jboss-cli.sh --command="patch apply /opt/jboss/jboss-eap-$EAP_VERSION_MAJOR.$EAP_VERSION_MINOR.$EAP_VERSION_PATCH-patch.zip --override-all" \
     && unzip -qo /opt/jboss/$BPMS_DEPLOYABLE  -d $BPMS_HOME/.. \
-    && rm -rf /opt/jboss/$BPMS_DEPLOYABLE /opt/jboss/$EAP_INSTALLER /opt/jboss/installation-eap /opt/jboss/installation-eap.variables $BPMS_HOME/standalone/configuration/standalone_xml_history/
-
+    && unzip -q /opt/jboss/$BPMS_PATCH -d $BPMS_HOME/.. \
+    && cd $BPMS_HOME/../$BPMS_PATCH_FOLDER \
+    && ./apply-updates.sh $BPMS_HOME eap7.x \
+    && cd - &> /dev/null \
+    && rm -rf /opt/jboss/$BPMS_DEPLOYABLE /opt/jboss/$BPMS_PATCH /opt/jboss/$EAP_INSTALLER /opt/jboss/installation-eap /opt/jboss/installation-eap.variables $BPMS_HOME/standalone/configuration/standalone_xml_history/ $BPMS_HOME/../$BPMS_PATCH_FOLDER
 
 # Create users and add support files
 RUN $BPMS_HOME/bin/add-user.sh -a -r ApplicationRealm -u bpmsAdmin -p bpmsuite1! -ro analyst,admin,manager,user,kie-server,kiemgmt,rest-all --silent \


### PR DESCRIPTION
This PR adds the installation of the BPMS Update 4 Patch.

I'm not a windows guy, so i didn't change the _ps1_ script, it has to be updated.

Regarding the patch installation, I had to _cd_ the patch's directory, if this wasn't done, patching failed with the following error:
```
Error: Could not find or load main class org.jboss.brmsbpmsuite.patching.client.BPMSuiteClientPatcherApp
```